### PR TITLE
Upgrade Avalonia to 12.1.0 and migrate the test stack to xunit v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # The Avalonia packages must move in lockstep; partial bumps leave a
+      # mixed-version tree that fails at runtime (see closed PRs #6-#9).
+      avalonia:
+        patterns:
+          - "Avalonia*"
 
   # GitHub Actions workflows
   - package-ecosystem: "github-actions"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 IMPROVEMENTS:
 
+ * gui: upgraded the UI framework from Avalonia 11.3 to 12.1.
  * docs: the README's CLI reference is again the verbatim `--help` output —
    it had drifted from the 1.8.1/1.9.2 help-text reformat (single-column
    option descriptions, fuller --full-erase/--trust-header/bake-save text).

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,18 +8,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.3.18" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.18" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.18" />
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.18" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.18" />
+    <PackageVersion Include="Avalonia" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.10" />
     <PackageVersion Include="System.IO.Ports" Version="10.0.10" />
     <PackageVersion Include="Terminal.Gui" Version="2.4.17" />
 
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -7,6 +7,8 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!-- xunit v3 test projects are executables, not classlibs. -->
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <!-- The xunit test stack every tests/ project uses; project files add
@@ -14,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 


### PR DESCRIPTION
Supersedes the four partial Dependabot bumps (#6, #7, #8, #9), which each moved only a subset of the Avalonia package family to 12.1.0 and left a mixed 11.x/12.x tree that crashes the headless GUI test host (`TypeLoadException: Could not load type 'Avalonia.Platform.IOptionalFeatureProvider'`).

- All five Avalonia packages move to 12.1.0 together.
- Avalonia 12's `Avalonia.Headless.XUnit` depends on xunit v3, so the shared test stack in `tests/Directory.Build.props` migrates from xunit 2.9.3 to `xunit.v3` 3.2.2 (v3 test projects build as executables — `OutputType Exe`).
- Adds a Dependabot `groups:` entry so future Avalonia bumps arrive as one coherent PR.

Verified locally with a clean `--no-incremental` build under `-warnaserror` (0 warnings) and the full suite: 123 Core + 37 TUI + 26 GUI headless tests pass, including the Linux DBus shutdown-workaround tests from v1.9.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)